### PR TITLE
Benchmark jmd files for ROCK2 and ROCK4

### DIFF
--- a/benchmarks/StiffODE/Hires.jmd
+++ b/benchmarks/StiffODE/Hires.jmd
@@ -72,7 +72,10 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>CVODE_BDF()),
           Dict(:alg=>rodas()),
           Dict(:alg=>radau()),
-          Dict(:alg=>lsoda())]
+          Dict(:alg=>lsoda()),
+          Dict(:alg=>ROCK2()),
+          Dict(:alg=>ROCK4())
+          ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)
 plot(wp)
@@ -151,7 +154,9 @@ setups = [Dict(:alg=>GRK4A()),
           Dict(:alg=>Rodas5()),
           Dict(:alg=>rodas()),
           Dict(:alg=>radau()),
-          Dict(:alg=>lsoda())
+          Dict(:alg=>lsoda()),
+          #Dict(:alg=>ROCK2()),   #Needs more iterations
+          Dict(:alg=>ROCK4())
 ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5))

--- a/benchmarks/StiffODE/Orego.jmd
+++ b/benchmarks/StiffODE/Orego.jmd
@@ -81,7 +81,10 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>CVODE_BDF()),
           Dict(:alg=>rodas()),
           Dict(:alg=>radau()),
-          Dict(:alg=>lsoda())]
+          Dict(:alg=>lsoda()),
+          Dict(:alg=>ROCK2()),
+          Dict(:alg=>ROCK4())
+          ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)
 plot(wp)
@@ -156,7 +159,9 @@ setups = [Dict(:alg=>GRK4A()),
           Dict(:alg=>Rodas4()),
           Dict(:alg=>rodas()),
           Dict(:alg=>radau()),
-          Dict(:alg=>lsoda())
+          Dict(:alg=>lsoda()),
+          #Dict(:alg=>ROCK2()), #Needs more iterations
+          Dict(:alg=>ROCK4())
 ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)

--- a/benchmarks/StiffODE/ROBER.jmd
+++ b/benchmarks/StiffODE/ROBER.jmd
@@ -79,7 +79,10 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>TRBDF2()),
           Dict(:alg=>rodas()),
           Dict(:alg=>lsoda()),
-          Dict(:alg=>radau())]
+          Dict(:alg=>radau())
+          #Dict(:alg=>ROCK2())    #Unstable
+          #Dict(:alg=>ROCK3())    #needs more iterations
+          ]
 gr()
 names = ["Rosenbrock23" "Rodas3" "TRBDF2" "rodas" "lsoda" "radau"]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;names=names,
@@ -127,6 +130,8 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>TRBDF2()),
           Dict(:alg=>rodas()),
           Dict(:alg=>lsoda()),
+          #Dict(:alg=>ROCK2())    #needs more iterations
+          #Dict(:alg=>ROCK3())    #needs more iterations
           Dict(:alg=>radau())]
 names = ["Rosenbrock23" "Rodas3" "TRBDF2" "rodas" "lsoda" "radau"]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;names=names,


### PR DESCRIPTION
@ChrisRackauckas  this adds ROCK2 and ROCK4 to setups.They are commented out whenever they fail.
Also not added to Pollution.jl, Filament.jl and Vanderpol.jl because they are too stiff for ROCK methods.